### PR TITLE
Add "Main Hand" to list of categories

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -26,6 +26,7 @@ const.GEAR_SECTION_ORDER = {
     "Finger",
     "Trinket",
     "Two-Hand",
+    "Main Hand",
     "One-Hand",
     "Off Hand",
     "Held In Off-hand",


### PR DESCRIPTION
Fixes #5 and #6 (they seem to be duplicates). Tested on Cataclysm Classic (same problem there)